### PR TITLE
Update resistance_variants.csv

### DIFF
--- a/db/Mycobacteroides_abscessus/resistance_variants.csv
+++ b/db/Mycobacteroides_abscessus/resistance_variants.csv
@@ -7,7 +7,6 @@ rrl,n.2271A>G,macrolides,resistance,,10.1038/s41467-021-25484-9
 rrl,n.2271A>T,macrolides,resistance,,10.1038/s41467-021-25484-9
 rrl,n.2281G>A,macrolides,resistance,,10.1038/s41467-021-25484-9
 rrl,n.2281G>C,macrolides,resistance,,10.1038/s41467-021-25484-9
-rrl,n.2281G>T,macrolides,resistance,,10.1038/s41467-021-25484-9
 rrl,n.2293A>C,macrolides,resistance,,10.1038/s41467-021-25484-9
 rrl,n.2293A>G,macrolides,resistance,,10.1038/s41467-021-25484-9
 rrl,n.2293A>T,macrolides,resistance,,10.1038/s41467-021-25484-9
@@ -18,9 +17,7 @@ rrl,n.1932A>G,macrolides,resistance,,10.1128/AAC.01204-18
 rrl,n.2039A>G,macrolides,resistance,,10.1128/AAC.01204-18
 rrl,n.2269A>G,macrolides,resistance,,10.1128/AAC.01204-18
 rrl,n.2279G>A,macrolides,resistance,,10.1128/AAC.01204-18
-rrs,n.1375A>C,amikacin,resistance,,
 rrs,n.1375A>G,amikacin,resistance,,10.1128/AAC.01204-18
-rrs,n.1375A>T,amikacin,resistance,,
 rrs,n.1373T>A,amikacin,resistance,,10.1128/AAC.01204-18
 rrs,n.1376C>T,amikacin,resistance,,10.1128/AAC.01204-18
 MAB_2297,frameshift,macrolides,sensitivity,Override=MAB_2297:functional_gene,10.1038/s41467-021-25484-9


### PR DESCRIPTION
Starting from previous updated list (which removed wrong mutations and inserted additional mutations based on the Lipworth 2018 publication):
- removed 3 mutations with no reference